### PR TITLE
[FEAT]Error formatting/#6

### DIFF
--- a/src/main/java/com/sansung_gorogoro/file_server/application/usecase/StartUploadUseCase.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/application/usecase/StartUploadUseCase.java
@@ -22,10 +22,6 @@ public class StartUploadUseCase {
     private final UploadPolicyProperties props;
 
     public StartUploadResult create(StartUploadRequest req, Long ownerUserId) {
-        if (ownerUserId == null) {
-            throw new IllegalArgumentException("ownerUserId는 필수입니다. ");
-        }
-
         LocalDateTime expiresAt = expiryProvider.calculateExpiresAt();
 
         UploadSession session = UploadSession.start(ownerUserId, req.declaredTotalSize(), req.originalFileName(), expiresAt);

--- a/src/main/java/com/sansung_gorogoro/file_server/common/error/ErrorCode.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/common/error/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.sansung_gorogoro.file_server.common.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/sansung_gorogoro/file_server/common/error/code/FileErrorCode.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/common/error/code/FileErrorCode.java
@@ -34,7 +34,8 @@ public enum FileErrorCode implements ErrorCode {
     DECLARED_TOTAL_SIZE_REQUIRED(HttpStatus.BAD_REQUEST, "FS-022", "업로드 파일 크기는 필수입니다."),
     DECLARED_TOTAL_SIZE_MUST_MORE_THAN_ZERO(HttpStatus.BAD_REQUEST, "FS-023", "업로드 파일 크기는 0보다 커야 합니다."),
     ORIGINAL_FILE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "FS-025", "원본 파일명은 필수입니다."),
-    ORIGINAL_FILE_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "FS-026", "원본 파일명은 255자를 초과할 수 없습니다.");
+    ORIGINAL_FILE_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "FS-026", "원본 파일명은 255자를 초과할 수 없습니다."),
+    EXPIRES_AT_REQUIRED(HttpStatus.BAD_REQUEST, "FS-027", "만료시간은 필수입니다.")
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/sansung_gorogoro/file_server/common/error/code/FileErrorCode.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/common/error/code/FileErrorCode.java
@@ -1,0 +1,42 @@
+package com.sansung_gorogoro.file_server.common.error.code;
+
+import com.sansung_gorogoro.file_server.common.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum FileErrorCode implements ErrorCode {
+    // ===================== Upload Session / Chunk (Domain) =====================
+    UPLOAD_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "FS-001", "존재하지 않는 업로드 세션입니다."),
+    UPLOAD_SESSION_EXPIRED(HttpStatus.GONE, "FS-002", "만료된 업로드 세션입니다."),
+    UPLOAD_SESSION_STATUS_NOT_ACTIVE(HttpStatus.CONFLICT, "FS-003", "활성 상태가 아닌 업로드 세션입니다."),
+    UPLOAD_SESSION_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "FS-004", "해당 업로드 세션에 접근 권한이 없습니다."),
+    UPLOAD_SESSION_OFFSET_MISMATCH(HttpStatus.CONFLICT, "FS-005", "업로드 오프셋이 일치하지 않습니다."),
+    UPLOAD_SESSION_NOT_UPLOADING(HttpStatus.BAD_REQUEST, "FS-006", "업로드 중인 세션이 아닙니다."),
+    UPLOAD_CHUNK_EMPTY(HttpStatus.BAD_REQUEST, "FS-007", "업로드 청크가 비어 있습니다."),
+    UPLOAD_CHUNK_SIZE_EXCEEDS_LIMIT(HttpStatus.PAYLOAD_TOO_LARGE, "FS-008", "청크 크기가 허용 범위를 초과했습니다."),
+
+    // ===================== Request / Controller (Web) =====================
+    REQUEST_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "FS-010", "요청 값이 유효하지 않습니다."),
+    REQUEST_BINDING_FAILED(HttpStatus.BAD_REQUEST, "FS-011", "요청 파라미터 바인딩에 실패했습니다."),
+    REQUEST_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "FS-012", "요청 파라미터 타입이 유효하지 않습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "FS-013", "지원하지 않는 HTTP 메서드입니다."),
+
+    // ===================== Internal / Infra =====================
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FS-014", "서버 내부 오류가 발생했습니다."),
+    UPLOAD_TEMP_DIR_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FS-020", "파일 저장소 초기화에 실패했습니다."),
+
+    // ===================== Validation (Input Constraints) =====================
+    OWNER_USER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "FS-021", "소유자 아이디는 필수입니다."),
+    OWNER_USER_ID_MUST_MORE_THAN_ZERO(HttpStatus.BAD_REQUEST, "FS-024", "소유자 아이디는 0보다 커야 합니다."),
+    DECLARED_TOTAL_SIZE_REQUIRED(HttpStatus.BAD_REQUEST, "FS-022", "업로드 파일 크기는 필수입니다."),
+    DECLARED_TOTAL_SIZE_MUST_MORE_THAN_ZERO(HttpStatus.BAD_REQUEST, "FS-023", "업로드 파일 크기는 0보다 커야 합니다."),
+    ORIGINAL_FILE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "FS-025", "원본 파일명은 필수입니다."),
+    ORIGINAL_FILE_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "FS-026", "원본 파일명은 255자를 초과할 수 없습니다.");
+    ;
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/sansung_gorogoro/file_server/common/exception/BusinessException.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/common/exception/BusinessException.java
@@ -1,0 +1,86 @@
+package com.sansung_gorogoro.file_server.common.exception;
+
+import com.sansung_gorogoro.file_server.common.error.ErrorCode;
+import com.sansung_gorogoro.file_server.common.response.FieldError;
+import com.sansung_gorogoro.file_server.presentation.advice.FileControllerAdvice;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+public class BusinessException extends RuntimeException{
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String code;
+    private Throwable cause;
+
+    private BusinessException(Builder builder) {
+        super(builder.getMessage(), builder.cause);
+        this.httpStatus = builder.httpStatus;
+        this.message = builder.getMessage();
+        this.code = builder.code;
+        this.cause = builder.cause;
+    }
+    public interface BusinessExceptionBuilder {
+        BusinessExceptionBuilder withId(Long... ids);
+        BusinessExceptionBuilder withField(String... fields);
+        BusinessExceptionBuilder withCause(Throwable cause);
+
+        BusinessException build();
+    }
+
+    public static BusinessExceptionBuilder builder(ErrorCode errorCode) {
+        return new Builder(errorCode);
+    }
+
+    private static class Builder implements BusinessExceptionBuilder {
+        private final HttpStatus httpStatus;
+        private final String messageTemplate;
+        private final List<Object> params = new ArrayList<>();
+        private final String code;
+        private Throwable cause;
+
+        public Builder(ErrorCode errorCode) {
+            this.httpStatus = errorCode.getHttpStatus();
+            this.messageTemplate = errorCode.getMessage();
+            this.code = errorCode.getCode();
+        }
+
+        public Builder withId(Long... ids) {
+            this.params.addAll(Arrays.asList(ids));
+            return this;
+        }
+
+        public Builder withField(String... fields) {
+            this.params.addAll(Arrays.asList(fields));
+            return this;
+        }
+
+        public Builder withCause(Throwable cause) {
+            this.cause = cause;
+            return this;
+        }
+
+        private String getMessage() {
+            if (params.isEmpty()) {
+                return messageTemplate;
+            }
+            return String.format(messageTemplate, params.toArray());
+        }
+
+        private String getCode() {
+            return code;
+        }
+
+        public BusinessException build() {
+            return new BusinessException(this);
+        }
+    }
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/sansung_gorogoro/file_server/common/response/ErrorResponse.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/common/response/ErrorResponse.java
@@ -1,0 +1,24 @@
+package com.sansung_gorogoro.file_server.common.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ErrorResponse(
+        LocalDateTime timestamp,
+        String errorCode,
+        String message,
+        List<FieldError> errors
+) {
+    public static ErrorResponse of(
+            String errorCode,
+            String message,
+            List<FieldError> errors
+    ) {
+        return new ErrorResponse(
+                LocalDateTime.now(),
+                errorCode,
+                message,
+                errors
+        );
+    }
+}

--- a/src/main/java/com/sansung_gorogoro/file_server/common/response/FieldError.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/common/response/FieldError.java
@@ -1,0 +1,8 @@
+package com.sansung_gorogoro.file_server.common.response;
+
+public record FieldError(
+        String field,
+        Object rejectedValue,
+        String reason
+) {
+}

--- a/src/main/java/com/sansung_gorogoro/file_server/common/validate/Validators.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/common/validate/Validators.java
@@ -1,0 +1,31 @@
+package com.sansung_gorogoro.file_server.common.validate;
+
+import com.sansung_gorogoro.file_server.common.error.code.FileErrorCode;
+import com.sansung_gorogoro.file_server.common.exception.BusinessException;
+
+public class Validators {
+    public static Long requirePositive(
+            Long value,
+            FileErrorCode requiredCode,
+            FileErrorCode notPositiveCode
+    ) {
+        if (value == null) throw BusinessException.builder(requiredCode).build();
+        if (value <= 0) throw BusinessException.builder(notPositiveCode).build();
+        return value;
+    }
+
+    public static String validateString(
+            String value,
+            int maxLen,
+            FileErrorCode requiredCode,
+            FileErrorCode tooLongCode
+    ) {
+        if (value == null || value.isBlank()) {
+            throw BusinessException.builder(requiredCode).build();
+        }
+        if (value.length() > maxLen) {
+            throw BusinessException.builder(tooLongCode).build();
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/sansung_gorogoro/file_server/config/JacksonConfig.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/config/JacksonConfig.java
@@ -1,0 +1,30 @@
+package com.sansung_gorogoro.file_server.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.CoercionAction;
+import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
+import com.fasterxml.jackson.databind.type.LogicalType;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper(Jackson2ObjectMapperBuilder builder) {
+        ObjectMapper om = builder.build();
+
+        // 1) 숫자/불리언 -> String 강제 변환 금지
+        om.coercionConfigFor(LogicalType.Textual)
+                .setCoercion(CoercionInputShape.Integer, CoercionAction.Fail)
+                .setCoercion(CoercionInputShape.Float, CoercionAction.Fail)
+                .setCoercion(CoercionInputShape.Boolean, CoercionAction.Fail);
+
+        // 2) String -> 숫자 강제 변환 금지("123"도 거부)
+        om.coercionConfigFor(LogicalType.Integer)
+                .setCoercion(CoercionInputShape.String, CoercionAction.Fail);
+
+        return om;
+    }
+}

--- a/src/main/java/com/sansung_gorogoro/file_server/domain/UploadSession.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/domain/UploadSession.java
@@ -1,5 +1,7 @@
 package com.sansung_gorogoro.file_server.domain;
 
+import com.sansung_gorogoro.file_server.common.error.code.FileErrorCode;
+import com.sansung_gorogoro.file_server.common.validate.Validators;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -19,6 +21,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+import static com.sansung_gorogoro.file_server.domain.constants.UploadConstraints.ORIGINAL_FILE_NAME_MAX_LEN;
+
 @Getter
 @Entity
 @Table(name = "upload_session")
@@ -32,7 +36,7 @@ public class UploadSession {
     @Column(name = "declared_total_size", nullable = false)
     private Long declaredTotalSize;
 
-    @Column(name = "original_file_name", nullable = false, length = 255)
+    @Column(name = "original_file_name", nullable = false, length = ORIGINAL_FILE_NAME_MAX_LEN)
     private String originalFileName;
 
     @Column(name = "next_offset", nullable = false)
@@ -57,9 +61,22 @@ public class UploadSession {
     private LocalDateTime updatedAt;
 
     protected UploadSession (Long ownerUserId, Long declaredTotalSize, String originalFileName, LocalDateTime expiresAt){
-        this.ownerUserId = requirePositive(ownerUserId, "ownerUserId");
-        this.declaredTotalSize = requirePositive(declaredTotalSize, "declaredTotalSize");
-        this.originalFileName = validateOriginalFileName(originalFileName);
+        this.ownerUserId = Validators.requirePositive(
+                ownerUserId,
+                FileErrorCode.OWNER_USER_ID_REQUIRED,
+                FileErrorCode.OWNER_USER_ID_MUST_MORE_THAN_ZERO);
+        this.declaredTotalSize = Validators.requirePositive(
+                declaredTotalSize,
+                FileErrorCode.DECLARED_TOTAL_SIZE_REQUIRED,
+                FileErrorCode.DECLARED_TOTAL_SIZE_MUST_MORE_THAN_ZERO);
+
+        this.originalFileName = Validators.validateString(
+                originalFileName,
+                ORIGINAL_FILE_NAME_MAX_LEN,
+                FileErrorCode.ORIGINAL_FILE_NAME_REQUIRED,
+                FileErrorCode.ORIGINAL_FILE_NAME_TOO_LONG
+        );
+
         this.status = UploadSessionStatus.UPLOADING;
         this.nextOffset = 0L;
         this.expiresAt = Objects.requireNonNull(expiresAt, "expiresAt은 필수입니다");
@@ -70,21 +87,5 @@ public class UploadSession {
                                       String originalFileName,
                                       LocalDateTime expiresAt) {
         return new UploadSession(ownerUserId, declaredTotalSize, originalFileName, expiresAt);
-    }
-
-    private static Long requirePositive(Long value, String fieldName) {
-        if (value == null) throw new IllegalArgumentException(fieldName + "는 필수입니다.");
-        if (value <= 0) throw new IllegalArgumentException(fieldName + "는 0보다 커야 합니다.");
-        return value;
-    }
-
-    private static String validateOriginalFileName(String originalFileName) {
-        if (originalFileName == null || originalFileName.isBlank()) {
-            throw new IllegalArgumentException("originalFileName은 필수입니다.");
-        }
-        if (originalFileName.length() > 255) {
-            throw new IllegalArgumentException("originalFileName은 255자를 초과할 수 없습니다.");
-        }
-        return originalFileName;
     }
 }

--- a/src/main/java/com/sansung_gorogoro/file_server/domain/UploadSession.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/domain/UploadSession.java
@@ -79,7 +79,7 @@ public class UploadSession {
 
         this.status = UploadSessionStatus.UPLOADING;
         this.nextOffset = 0L;
-        this.expiresAt = Objects.requireNonNull(expiresAt, "expiresAt은 필수입니다");
+        this.expiresAt = Objects.requireNonNull(expiresAt, FileErrorCode.EXPIRES_AT_REQUIRED.getMessage());
     }
 
     public static UploadSession start(Long ownerUserId,

--- a/src/main/java/com/sansung_gorogoro/file_server/domain/constants/UploadConstraints.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/domain/constants/UploadConstraints.java
@@ -1,0 +1,6 @@
+package com.sansung_gorogoro.file_server.domain.constants;
+
+public class UploadConstraints {
+    private UploadConstraints() {}
+    public static final int ORIGINAL_FILE_NAME_MAX_LEN = 255;
+}

--- a/src/main/java/com/sansung_gorogoro/file_server/infrastructure/storage/TempUploadFileProvider.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/infrastructure/storage/TempUploadFileProvider.java
@@ -1,5 +1,7 @@
 package com.sansung_gorogoro.file_server.infrastructure.storage;
 
+import com.sansung_gorogoro.file_server.common.error.code.FileErrorCode;
+import com.sansung_gorogoro.file_server.common.exception.BusinessException;
 import com.sansung_gorogoro.file_server.infrastructure.config.UploadPolicyProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -28,7 +30,9 @@ public class TempUploadFileProvider {
         try {
             Files.createDirectories(baseDir);
         } catch (IOException e) {
-            throw new IllegalStateException("임시 업로드 디렉터리를 생성할 수 없습니다: " + baseDir, e);
+            throw BusinessException.builder(FileErrorCode.UPLOAD_TEMP_DIR_CREATE_FAILED)
+                    .withCause(e)
+                    .build();
         }
     }
 }

--- a/src/main/java/com/sansung_gorogoro/file_server/presentation/advice/FileControllerAdvice.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/presentation/advice/FileControllerAdvice.java
@@ -180,6 +180,14 @@ public class FileControllerAdvice {
     @ResponseBody
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<BusinessErrorCode> handleNotReadable(HttpMessageNotReadableException ex) {
+        Throwable root = ex.getRootCause();
+        log.debug("[NOT_READABLE] exType={}, rootType={}, rootMsg={}",
+                ex.getClass().getName(),
+                root != null ? root.getClass().getName() : "null",
+                root != null ? root.getMessage() : "null",
+                ex
+        );
+
         FileErrorCode ec = FileErrorCode.REQUEST_BINDING_FAILED;
         return ResponseEntity.status(ec.getHttpStatus())
                 .body(new BusinessErrorCode(ec.getCode(), ec.getMessage()));

--- a/src/main/java/com/sansung_gorogoro/file_server/presentation/advice/FileControllerAdvice.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/presentation/advice/FileControllerAdvice.java
@@ -1,0 +1,187 @@
+package com.sansung_gorogoro.file_server.presentation.advice;
+
+import com.sansung_gorogoro.file_server.common.exception.BusinessException;
+import com.sansung_gorogoro.file_server.common.error.code.FileErrorCode;
+import com.sansung_gorogoro.file_server.common.response.ErrorResponse;
+import com.sansung_gorogoro.file_server.common.response.FieldError;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.List;
+
+
+@Slf4j
+@RestControllerAdvice
+public class FileControllerAdvice {
+
+    @ResponseBody
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handlerMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        FileErrorCode ec = FileErrorCode.REQUEST_VALIDATION_FAILED;
+        List<FieldError> errors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> new FieldError(
+                        error.getField(),
+                        error.getRejectedValue(),
+                        error.getDefaultMessage()
+                ))
+                .toList();
+
+        ErrorResponse body = ErrorResponse.of(
+                ec.getCode(),
+                ec.getMessage(),
+                errors
+        );
+
+        log.debug("Validation error(MethodArgumentNotValidException): {}", errors, ex);
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ResponseBody
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ErrorResponse> handleBindException(BindException ex) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        FileErrorCode ec = FileErrorCode.REQUEST_BINDING_FAILED;
+        List<FieldError> errors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> new FieldError(
+                        error.getField(),
+                        error.getRejectedValue(),
+                        error.getDefaultMessage()
+                ))
+                .toList();
+
+        ErrorResponse body = ErrorResponse.of(
+                ec.getCode(),
+                ec.getMessage(),
+                errors
+        );
+
+        log.debug("Binding error(BindException): {}", errors, ex);
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ResponseBody
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        FileErrorCode ec = FileErrorCode.REQUEST_VALIDATION_FAILED;
+        List<FieldError> errors = ex.getConstraintViolations()
+                .stream()
+                .map(v -> new FieldError(
+                        v.getPropertyPath().toString(),
+                        v.getInvalidValue(),
+                        v.getMessage()
+                ))
+                .toList();
+
+        ErrorResponse body = ErrorResponse.of(
+                ec.getCode(),
+                ec.getMessage(),
+                errors
+        );
+
+        log.debug("Validation error(ConstraintViolationException): {}", errors, ex);
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ResponseBody
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        FileErrorCode ec = FileErrorCode.REQUEST_TYPE_MISMATCH;
+        ErrorResponse body = ErrorResponse.of(
+                ec.getCode(),
+                ec.getMessage() + ex.getName(),
+                null
+        );
+
+        log.debug("Type mismatch: {}", ex.getMessage(), ex);
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ResponseBody
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex) {
+        HttpStatus status = HttpStatus.METHOD_NOT_ALLOWED;
+        FileErrorCode ec = FileErrorCode.METHOD_NOT_ALLOWED;
+        ErrorResponse body = ErrorResponse.of(
+                ec.getCode(),
+                ec.getMessage(),
+                null
+        );
+
+        log.warn("Method not allowed: {}", ex.getMessage(), ex);
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ResponseBody
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<BusinessErrorCode> handleBusinessException(BusinessException ex) {
+        HttpStatus status = ex.getHttpStatus();
+
+        BusinessErrorCode body = new BusinessErrorCode(ex.getCode(), ex.getMessage());
+
+        // 비즈니스 예외는 warn 정도로 남겨두는 경우가 많음
+        log.warn("Business exception: code={}, message={}", ex.getCode(), ex.getMessage());
+
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ResponseBody
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+
+        ErrorResponse body = ErrorResponse.of(
+                "INTERNAL_SERVER_ERROR",
+                "서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+                null
+        );
+
+        log.error("Unexpected error", ex);
+        return ResponseEntity.status(status).body(body);
+    }
+
+    public record BusinessErrorCode(
+            String code,
+            String message
+    ) {}
+
+    @ResponseBody
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<BusinessErrorCode> handleMissingHeader(MissingRequestHeaderException ex) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        if ("X-User-Id".equals(ex.getHeaderName())) {
+            FileErrorCode ec = FileErrorCode.OWNER_USER_ID_REQUIRED;
+            BusinessErrorCode body = new BusinessErrorCode(ec.getCode(), ec.getMessage());
+            return ResponseEntity.status(status).body(body);
+        }
+
+        FileErrorCode ec = FileErrorCode.REQUEST_BINDING_FAILED;
+        BusinessErrorCode body = new BusinessErrorCode(ec.getCode(), ec.getMessage());
+        return ResponseEntity.status(ec.getHttpStatus()).body(body);
+    }
+
+    @ResponseBody
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<BusinessErrorCode> handleNotReadable(HttpMessageNotReadableException ex) {
+        FileErrorCode ec = FileErrorCode.REQUEST_BINDING_FAILED;
+        return ResponseEntity.status(ec.getHttpStatus())
+                .body(new BusinessErrorCode(ec.getCode(), ec.getMessage()));
+    }
+}

--- a/src/main/java/com/sansung_gorogoro/file_server/presentation/controller/UploadController.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/presentation/controller/UploadController.java
@@ -6,8 +6,11 @@ import com.sansung_gorogoro.file_server.presentation.request.StartUploadRequest;
 import com.sansung_gorogoro.file_server.presentation.response.StartUploadResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api")
@@ -17,12 +20,10 @@ public class UploadController {
     private final StartUploadUseCase startUploadUseCase;
 
     @PostMapping("/uploads")
-    public ResponseEntity<?> create (@RequestHeader("X-User-Id") Long ownerUserId,
+    public StartUploadResponse create(@RequestHeader("X-User-Id") Long ownerUserId,
                                      @RequestBody @Valid StartUploadRequest req) {
 
         StartUploadResult result = startUploadUseCase.create(req, ownerUserId);
-        StartUploadResponse response = StartUploadResponse.from(result);
-
-        return ResponseEntity.ok(response);
+        return StartUploadResponse.from(result);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 커스텀 예외 체계 도입 및 업로드 세션 생성 플로우에 적용
- 예외 응답 포맷 통일을 위한 ErrorResponse 및 전역 예외 핸들러 추가
- 업로드 정책 관련 하드코딩 값 상수화
- Jackson 타입 강제 변환 비활성화로 요청 검증 강화

---

## 💭 주의 사항
- Jackson coercion 비활성화로 인해 잘못된 타입 요청은 파싱 단계에서 400으로 차단됩니다.
- 업로드 세션 생성 시 검증 책임이 UseCase에서 Domain으로 이동했습니다.
---

## 💡 리뷰 포인트
- 커스텀 예외/에러코드 분리 기준이 적절한지
- 도메인 검증 위치(UploadSession 생성자) 적절성
- 예외 응답 포맷(ErrorResponse) 구조 적절성
---

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트


