### PR TITLE
[File] 업로드 파일 확장자 검증 및 정책 타입 추가

### DIFF
--- a/src/main/java/com/sansung_gorogoro/file_server/application/policy/UploadPolicyProvider.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/application/policy/UploadPolicyProvider.java
@@ -1,0 +1,14 @@
+package com.sansung_gorogoro.file_server.application.policy;
+
+import com.sansung_gorogoro.file_server.domain.ExtensionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UploadPolicyProvider {
+
+    public void allowedExtensions(String originalFileName) {
+        ExtensionType.fromOriginalFileName(originalFileName);
+    }
+}

--- a/src/main/java/com/sansung_gorogoro/file_server/application/policy/UploadPolicyProvider.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/application/policy/UploadPolicyProvider.java
@@ -1,11 +1,9 @@
 package com.sansung_gorogoro.file_server.application.policy;
 
 import com.sansung_gorogoro.file_server.domain.ExtensionType;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class UploadPolicyProvider {
 
     public void allowedExtensions(String originalFileName) {

--- a/src/main/java/com/sansung_gorogoro/file_server/application/usecase/StartUploadUseCase.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/application/usecase/StartUploadUseCase.java
@@ -1,5 +1,6 @@
 package com.sansung_gorogoro.file_server.application.usecase;
 
+import com.sansung_gorogoro.file_server.application.policy.UploadPolicyProvider;
 import com.sansung_gorogoro.file_server.application.policy.UploadSessionExpiryProvider;
 import com.sansung_gorogoro.file_server.application.result.StartUploadResult;
 import com.sansung_gorogoro.file_server.domain.UploadSession;
@@ -18,12 +19,14 @@ public class StartUploadUseCase {
 
     private final UploadSessionRepository sessionRepository;
     private final UploadSessionExpiryProvider expiryProvider;
+    private final UploadPolicyProvider uploadPolicyProvider;
     private final TempUploadFileProvider tempUploadFileProvider;
     private final UploadPolicyProperties props;
 
+
     public StartUploadResult create(StartUploadRequest req, Long ownerUserId) {
         LocalDateTime expiresAt = expiryProvider.calculateExpiresAt();
-
+        uploadPolicyProvider.allowedExtensions(req.originalFileName());
         UploadSession session = UploadSession.start(ownerUserId, req.declaredTotalSize(), req.originalFileName(), expiresAt);
         sessionRepository.save(session);
 

--- a/src/main/java/com/sansung_gorogoro/file_server/common/error/code/FileErrorCode.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/common/error/code/FileErrorCode.java
@@ -35,7 +35,9 @@ public enum FileErrorCode implements ErrorCode {
     DECLARED_TOTAL_SIZE_MUST_MORE_THAN_ZERO(HttpStatus.BAD_REQUEST, "FS-023", "업로드 파일 크기는 0보다 커야 합니다."),
     ORIGINAL_FILE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "FS-025", "원본 파일명은 필수입니다."),
     ORIGINAL_FILE_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "FS-026", "원본 파일명은 255자를 초과할 수 없습니다."),
-    EXPIRES_AT_REQUIRED(HttpStatus.BAD_REQUEST, "FS-027", "만료시간은 필수입니다.")
+    EXPIRES_AT_REQUIRED(HttpStatus.BAD_REQUEST, "FS-027", "만료시간은 필수입니다."),
+    ORIGINAL_FILE_NAME_EXTENSION_NOT_FOUND(HttpStatus.BAD_REQUEST, "FS-028", "확장자를 찾지 못했습니다."),
+    ORIGINAL_FILE_NAME_EXTENSION_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "FS-029", "지원하는 확장자가 아닙니다.")
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/sansung_gorogoro/file_server/domain/ExtensionType.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/domain/ExtensionType.java
@@ -1,0 +1,32 @@
+package com.sansung_gorogoro.file_server.domain;
+
+import com.sansung_gorogoro.file_server.common.error.code.FileErrorCode;
+import com.sansung_gorogoro.file_server.common.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+public enum ExtensionType {
+    MP4("mp4", ResourceType.VIDEO);
+    
+    private final String extension;
+    private final ResourceType resourceType;
+
+    public static ExtensionType fromOriginalFileName(String originalFileName) {
+        String ext = extractExtension(originalFileName);
+
+        return Arrays.stream(values())
+                .filter(e -> e.extension.equalsIgnoreCase(ext))
+                .findFirst()
+                .orElseThrow(()-> BusinessException.builder(FileErrorCode.ORIGINAL_FILE_NAME_EXTENSION_NOT_SUPPORTED).build());
+    }
+
+    private static String extractExtension(String originalFileName) {
+        int idx = originalFileName.lastIndexOf('.');
+        if (idx == -1 || idx == originalFileName.length() -1) {
+            throw BusinessException.builder(FileErrorCode.ORIGINAL_FILE_NAME_EXTENSION_NOT_FOUND).build();
+        }
+        return originalFileName.substring(idx+1).trim().toLowerCase();
+    }
+}

--- a/src/main/java/com/sansung_gorogoro/file_server/domain/ResourceType.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/domain/ResourceType.java
@@ -1,0 +1,6 @@
+package com.sansung_gorogoro.file_server.domain;
+
+public enum ResourceType {
+    VIDEO
+    ;
+}


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ✨ 요약
업로드 세션 생성 시점에 파일 확장자를 검증하는 로직을 추가했습니다.  
현재는 영상 업로드를 우선 지원하여 `mp4` 확장자만 허용하며, 추후 이미지 업로드 확장을 고려해 타입 구조를 함께 정리했습니다.


## 📝 작업 내용
- 업로드 파일 타입 분리를 위한 `ResourceType` enum 추가  
  - 현재는 `VIDEO` 타입만 정의
- 파일 확장자 검증을 담당하는 `ExtensionType` enum 구현
  - `originalFileName` 기반 확장자 추출 및 지원 여부 검증
- 확장자 검증 실패 시 사용될 `FileErrorCode` 신규 추가
- 업로드 세션 생성(`StartUploadUseCase`) 단계에서 확장자 검증 로직 적용

## 💭 주의 사항
- 이번 PR에서는 업로드 세션 생성 시점에 **확장자 검증만 수행**합니다.
- `resourceType`은 업로드 최종 완료 시점에 `Resource` 생성/확정 과정에서 저장할 예정입니다.
- 현재는 `mp4` 확장자만 허용하며, 이미지 업로드 관련 확장자는 추후 추가될 수 있습니다.


## 💡 리뷰 포인트
- 확장자 검증을 세션 생성 단계에서 수행하는 설계가 적절한지
- `ExtensionType` / `ResourceType` 역할 분리가 확장성 측면에서 괜찮은지
- 확장자 검증 관련 에러 코드 분리 기준이 적절한지

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)