### PR TITLE
[FEAT] 청크 업로드 API 구현 (Upload-Offset 기반)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,16 @@ build/
 # IntelliJ HTTP Client files
 http/files/*.http
 
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+
 ### IntelliJ IDEA ###
 .idea/
 *.iml

--- a/src/main/java/com/sansung_gorogoro/file_server/application/result/ChunkUploadResult.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/application/result/ChunkUploadResult.java
@@ -1,0 +1,13 @@
+package com.sansung_gorogoro.file_server.application.result;
+
+import com.sansung_gorogoro.file_server.domain.UploadSession;
+
+public record ChunkUploadResult(
+        Long nextOffset
+) {
+    public static ChunkUploadResult from(UploadSession session) {
+        return new ChunkUploadResult(
+                session.getNextOffset()
+        );
+    }
+}

--- a/src/main/java/com/sansung_gorogoro/file_server/application/usecase/ChunkUploadUseCase.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/application/usecase/ChunkUploadUseCase.java
@@ -31,6 +31,7 @@ public class ChunkUploadUseCase {
 
         session.assertOwner(ownerUserId);
         validateChunkSize(contentLength);
+        validateChunkWithinRemainingBytes(contentLength, session.getDeclaredTotalSize(), uploadOffset);
         session.assertExpectedOffset(uploadOffset);
         String tempFilePath = tempUploadFileProvider.resolveTempFilePath(session.getId()).toString();
 
@@ -48,6 +49,13 @@ public class ChunkUploadUseCase {
 
         if (contentLength == 0) {
             throw BusinessException.builder(FileErrorCode.UPLOAD_CHUNK_EMPTY).build();
+        }
+    }
+
+    private void validateChunkWithinRemainingBytes(Long contentLength, Long declaredTotalSize, Long uploadOffset) {
+        Long remaining = declaredTotalSize - uploadOffset;
+        if (contentLength > remaining) {
+            throw BusinessException.builder(FileErrorCode.UPLOAD_CHUNK_EXCEEDS_REMAINING).build();
         }
     }
 }

--- a/src/main/java/com/sansung_gorogoro/file_server/application/usecase/ChunkUploadUseCase.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/application/usecase/ChunkUploadUseCase.java
@@ -1,0 +1,53 @@
+package com.sansung_gorogoro.file_server.application.usecase;
+
+import com.sansung_gorogoro.file_server.application.result.ChunkUploadResult;
+import com.sansung_gorogoro.file_server.common.error.code.FileErrorCode;
+import com.sansung_gorogoro.file_server.common.exception.BusinessException;
+import com.sansung_gorogoro.file_server.domain.UploadSession;
+import com.sansung_gorogoro.file_server.domain.UploadSessionRepository;
+import com.sansung_gorogoro.file_server.infrastructure.config.UploadPolicyProperties;
+import com.sansung_gorogoro.file_server.infrastructure.storage.ChunkFileWriter;
+import com.sansung_gorogoro.file_server.infrastructure.storage.TempUploadFileProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Service
+@RequiredArgsConstructor
+public class ChunkUploadUseCase {
+
+    private final UploadSessionRepository repository;
+    private final UploadPolicyProperties props;
+    private final ChunkFileWriter writer;
+    private final TempUploadFileProvider tempUploadFileProvider;
+
+    @Transactional
+    public ChunkUploadResult chunk(Long sessionId, Long ownerUserId, Long uploadOffset, Long contentLength, InputStream body) throws IOException {
+        UploadSession session = repository.findById(sessionId)
+                .orElseThrow(()-> BusinessException.builder(FileErrorCode.UPLOAD_SESSION_NOT_FOUND).build());
+
+        session.assertOwner(ownerUserId);
+        validateChunkSize(contentLength);
+        session.assertExpectedOffset(uploadOffset);
+        String tempFilePath = tempUploadFileProvider.resolveTempFilePath(session.getId()).toString();
+
+        long written = writer.writeAtOffset(tempFilePath, uploadOffset, body);
+
+        session.applyChunkWritten(written);
+
+        return ChunkUploadResult.from(session);
+    }
+
+    private void validateChunkSize(Long contentLength) {
+        if (contentLength != -1 && contentLength > props.chunkMaxSizeBytes()) {
+            throw BusinessException.builder(FileErrorCode.UPLOAD_CHUNK_SIZE_EXCEEDS_LIMIT).build();
+        }
+
+        if (contentLength == 0) {
+            throw BusinessException.builder(FileErrorCode.UPLOAD_CHUNK_EMPTY).build();
+        }
+    }
+}

--- a/src/main/java/com/sansung_gorogoro/file_server/common/error/code/FileErrorCode.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/common/error/code/FileErrorCode.java
@@ -17,15 +17,17 @@ public enum FileErrorCode implements ErrorCode {
     UPLOAD_SESSION_NOT_UPLOADING(HttpStatus.BAD_REQUEST, "FS-006", "업로드 중인 세션이 아닙니다."),
     UPLOAD_CHUNK_EMPTY(HttpStatus.BAD_REQUEST, "FS-007", "업로드 청크가 비어 있습니다."),
     UPLOAD_CHUNK_SIZE_EXCEEDS_LIMIT(HttpStatus.PAYLOAD_TOO_LARGE, "FS-008", "청크 크기가 허용 범위를 초과했습니다."),
+    UPLOAD_OFFSET_EXCEEDS_DECLARED_TOTAL_SIZE(HttpStatus.BAD_REQUEST, "FS-009", "업로드 오프셋은 원본 파일 전체 크기보다 클 수 없습니다."),
+    UPLOAD_CHUNK_WRITE_FAILED(HttpStatus.BAD_REQUEST, "FS-010", "청크 데이터 기록에 실패했습니다"),
 
     // ===================== Request / Controller (Web) =====================
-    REQUEST_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "FS-010", "요청 값이 유효하지 않습니다."),
-    REQUEST_BINDING_FAILED(HttpStatus.BAD_REQUEST, "FS-011", "요청 파라미터 바인딩에 실패했습니다."),
-    REQUEST_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "FS-012", "요청 파라미터 타입이 유효하지 않습니다."),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "FS-013", "지원하지 않는 HTTP 메서드입니다."),
+    REQUEST_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "FS-011", "요청 값이 유효하지 않습니다."),
+    REQUEST_BINDING_FAILED(HttpStatus.BAD_REQUEST, "FS-012", "요청 파라미터 바인딩에 실패했습니다."),
+    REQUEST_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "FS-013", "요청 파라미터 타입이 유효하지 않습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "FS-014", "지원하지 않는 HTTP 메서드입니다."),
 
     // ===================== Internal / Infra =====================
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FS-014", "서버 내부 오류가 발생했습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FS-015", "서버 내부 오류가 발생했습니다."),
     UPLOAD_TEMP_DIR_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FS-020", "파일 저장소 초기화에 실패했습니다."),
 
     // ===================== Validation (Input Constraints) =====================

--- a/src/main/java/com/sansung_gorogoro/file_server/common/error/code/FileErrorCode.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/common/error/code/FileErrorCode.java
@@ -15,32 +15,34 @@ public enum FileErrorCode implements ErrorCode {
     UPLOAD_SESSION_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "FS-004", "해당 업로드 세션에 접근 권한이 없습니다."),
     UPLOAD_SESSION_OFFSET_MISMATCH(HttpStatus.CONFLICT, "FS-005", "업로드 오프셋이 일치하지 않습니다."),
     UPLOAD_SESSION_NOT_UPLOADING(HttpStatus.BAD_REQUEST, "FS-006", "업로드 중인 세션이 아닙니다."),
+
     UPLOAD_CHUNK_EMPTY(HttpStatus.BAD_REQUEST, "FS-007", "업로드 청크가 비어 있습니다."),
     UPLOAD_CHUNK_SIZE_EXCEEDS_LIMIT(HttpStatus.PAYLOAD_TOO_LARGE, "FS-008", "청크 크기가 허용 범위를 초과했습니다."),
     UPLOAD_OFFSET_EXCEEDS_DECLARED_TOTAL_SIZE(HttpStatus.BAD_REQUEST, "FS-009", "업로드 오프셋은 원본 파일 전체 크기보다 클 수 없습니다."),
-    UPLOAD_CHUNK_WRITE_FAILED(HttpStatus.BAD_REQUEST, "FS-010", "청크 데이터 기록에 실패했습니다"),
+    UPLOAD_CHUNK_WRITE_FAILED(HttpStatus.BAD_REQUEST, "FS-010", "청크 데이터 기록에 실패했습니다."),
+    UPLOAD_CHUNK_EXCEEDS_REMAINING(HttpStatus.CONFLICT, "FS-011", "청크 크기가 남은 업로드 가능 용량을 초과했습니다."),
 
     // ===================== Request / Controller (Web) =====================
-    REQUEST_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "FS-011", "요청 값이 유효하지 않습니다."),
-    REQUEST_BINDING_FAILED(HttpStatus.BAD_REQUEST, "FS-012", "요청 파라미터 바인딩에 실패했습니다."),
-    REQUEST_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "FS-013", "요청 파라미터 타입이 유효하지 않습니다."),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "FS-014", "지원하지 않는 HTTP 메서드입니다."),
-
-    // ===================== Internal / Infra =====================
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FS-015", "서버 내부 오류가 발생했습니다."),
-    UPLOAD_TEMP_DIR_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FS-020", "파일 저장소 초기화에 실패했습니다."),
+    REQUEST_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "FS-012", "요청 값이 유효하지 않습니다."),
+    REQUEST_BINDING_FAILED(HttpStatus.BAD_REQUEST, "FS-013", "요청 파라미터 바인딩에 실패했습니다."),
+    REQUEST_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "FS-014", "요청 파라미터 타입이 유효하지 않습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "FS-015", "지원하지 않는 HTTP 메서드입니다."),
 
     // ===================== Validation (Input Constraints) =====================
     OWNER_USER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "FS-021", "소유자 아이디는 필수입니다."),
-    OWNER_USER_ID_MUST_MORE_THAN_ZERO(HttpStatus.BAD_REQUEST, "FS-024", "소유자 아이디는 0보다 커야 합니다."),
     DECLARED_TOTAL_SIZE_REQUIRED(HttpStatus.BAD_REQUEST, "FS-022", "업로드 파일 크기는 필수입니다."),
     DECLARED_TOTAL_SIZE_MUST_MORE_THAN_ZERO(HttpStatus.BAD_REQUEST, "FS-023", "업로드 파일 크기는 0보다 커야 합니다."),
+    OWNER_USER_ID_MUST_MORE_THAN_ZERO(HttpStatus.BAD_REQUEST, "FS-024", "소유자 아이디는 0보다 커야 합니다."),
     ORIGINAL_FILE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "FS-025", "원본 파일명은 필수입니다."),
     ORIGINAL_FILE_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "FS-026", "원본 파일명은 255자를 초과할 수 없습니다."),
     EXPIRES_AT_REQUIRED(HttpStatus.BAD_REQUEST, "FS-027", "만료시간은 필수입니다."),
     ORIGINAL_FILE_NAME_EXTENSION_NOT_FOUND(HttpStatus.BAD_REQUEST, "FS-028", "확장자를 찾지 못했습니다."),
-    ORIGINAL_FILE_NAME_EXTENSION_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "FS-029", "지원하는 확장자가 아닙니다.")
-    ;
+    ORIGINAL_FILE_NAME_EXTENSION_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "FS-029", "지원하는 확장자가 아닙니다."),
+
+    // ===================== Internal / Infra =====================
+    UPLOAD_TEMP_DIR_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FS-020", "파일 저장소 초기화에 실패했습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FS-999", "서버 내부 오류가 발생했습니다.");
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/sansung_gorogoro/file_server/domain/UploadSession.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/domain/UploadSession.java
@@ -1,6 +1,7 @@
 package com.sansung_gorogoro.file_server.domain;
 
 import com.sansung_gorogoro.file_server.common.error.code.FileErrorCode;
+import com.sansung_gorogoro.file_server.common.exception.BusinessException;
 import com.sansung_gorogoro.file_server.common.validate.Validators;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -87,5 +88,42 @@ public class UploadSession {
                                       String originalFileName,
                                       LocalDateTime expiresAt) {
         return new UploadSession(ownerUserId, declaredTotalSize, originalFileName, expiresAt);
+    }
+
+    public void assertExpectedOffset(Long uploadOffset) {
+        if (!uploadOffset.equals(this.nextOffset)) {
+            throw BusinessException.builder(FileErrorCode.UPLOAD_SESSION_OFFSET_MISMATCH).build();
+        }
+    }
+
+    public void assertOwner(Long requesterUserId) {
+        if (requesterUserId == null) {
+            throw BusinessException.builder(FileErrorCode.OWNER_USER_ID_REQUIRED).build();
+        }
+
+        if (!Objects.equals(this.ownerUserId, requesterUserId)) {
+            throw BusinessException.builder(FileErrorCode.UPLOAD_SESSION_ACCESS_FORBIDDEN).build();
+        }
+    }
+
+    public void applyChunkWritten(long written) {
+        if (!status.equals(UploadSessionStatus.UPLOADING)) {
+            throw BusinessException.builder(FileErrorCode.UPLOAD_SESSION_STATUS_NOT_ACTIVE).build();
+        }
+
+        if (written <= 0) {
+            throw BusinessException.builder(FileErrorCode.UPLOAD_CHUNK_WRITE_FAILED).build();
+        }
+
+        Long newNextOffset = this.nextOffset + written;
+        if (newNextOffset > this.declaredTotalSize) {
+            throw BusinessException.builder(FileErrorCode.UPLOAD_OFFSET_EXCEEDS_DECLARED_TOTAL_SIZE).build();
+        }
+
+        advanceTo(newNextOffset);
+    }
+
+    private void advanceTo(Long newNextOffset) {
+        this.nextOffset = newNextOffset;
     }
 }

--- a/src/main/java/com/sansung_gorogoro/file_server/infrastructure/storage/ChunkFileWriter.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/infrastructure/storage/ChunkFileWriter.java
@@ -1,0 +1,50 @@
+package com.sansung_gorogoro.file_server.infrastructure.storage;
+
+import com.sansung_gorogoro.file_server.common.error.code.FileErrorCode;
+import com.sansung_gorogoro.file_server.common.exception.BusinessException;
+import com.sansung_gorogoro.file_server.infrastructure.config.UploadPolicyProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+@Component
+@RequiredArgsConstructor
+public class ChunkFileWriter {
+
+    private final UploadPolicyProperties props;
+
+    public long writeAtOffset(String tempFilePath, long offset, InputStream in) throws IOException {
+        byte[] buf = new byte[1024 * 64];
+        long written = 0;
+
+        try (FileChannel ch = FileChannel.open(
+                Paths.get(tempFilePath),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE
+        )){
+            ch.position(offset);
+
+            int read;
+
+            while ((read = in.read(buf)) != -1) {
+                written += read;
+
+                if (written > props.chunkMaxSizeBytes()) {
+                    throw BusinessException.builder(FileErrorCode.UPLOAD_CHUNK_SIZE_EXCEEDS_LIMIT).build();
+                }
+                ByteBuffer bb = ByteBuffer.wrap(buf, 0, read);
+
+                while (bb.hasRemaining()) {
+                    ch.write(bb);
+                }
+            }
+        }
+        return written;
+    }
+}

--- a/src/main/java/com/sansung_gorogoro/file_server/presentation/controller/UploadController.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/presentation/controller/UploadController.java
@@ -1,29 +1,51 @@
 package com.sansung_gorogoro.file_server.presentation.controller;
 
+import com.sansung_gorogoro.file_server.application.result.ChunkUploadResult;
 import com.sansung_gorogoro.file_server.application.result.StartUploadResult;
+import com.sansung_gorogoro.file_server.application.usecase.ChunkUploadUseCase;
 import com.sansung_gorogoro.file_server.application.usecase.StartUploadUseCase;
 import com.sansung_gorogoro.file_server.presentation.request.StartUploadRequest;
+import com.sansung_gorogoro.file_server.presentation.response.ChunkUploadResponse;
 import com.sansung_gorogoro.file_server.presentation.response.StartUploadResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+@Slf4j
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
 public class UploadController {
 
     private final StartUploadUseCase startUploadUseCase;
+    private final ChunkUploadUseCase chunkUploadUseCase;
 
-    @PostMapping("/uploads")
+    @PostMapping("/uploads/sessions")
     public StartUploadResponse create(@RequestHeader("X-User-Id") Long ownerUserId,
                                      @RequestBody @Valid StartUploadRequest req) {
 
         StartUploadResult result = startUploadUseCase.create(req, ownerUserId);
         return StartUploadResponse.from(result);
+    }
+
+    @PutMapping("/uploads/sessions/{sessionId}/chunks")
+    public ChunkUploadResponse uploadChunk(@PathVariable Long sessionId,
+                                           @RequestHeader("X-User-Id") Long ownerUserId,
+                                           @RequestHeader("Upload-Offset") Long uploadOffset,
+                                           @RequestBody byte[] body
+                                           ) throws IOException {
+        long contentLength = body.length;
+        ChunkUploadResult result = chunkUploadUseCase.chunk(sessionId, ownerUserId, uploadOffset, contentLength, new ByteArrayInputStream(body));
+        return ChunkUploadResponse.from(result);
     }
 }

--- a/src/main/java/com/sansung_gorogoro/file_server/presentation/response/ChunkUploadResponse.java
+++ b/src/main/java/com/sansung_gorogoro/file_server/presentation/response/ChunkUploadResponse.java
@@ -1,0 +1,12 @@
+package com.sansung_gorogoro.file_server.presentation.response;
+
+import com.sansung_gorogoro.file_server.application.result.ChunkUploadResult;
+
+public record ChunkUploadResponse (
+        Long nextOffset
+){
+    public static ChunkUploadResponse from (ChunkUploadResult result) {
+        return new ChunkUploadResponse(
+                result.nextOffset());
+    }
+}


### PR DESCRIPTION
## ✨ 요약
업로드 세션 기반 **청크 업로드 기능**을 구현했습니다.  
클라이언트가 전달한 오프셋을 기준으로 파일을 분할 업로드하고, 서버에서 오프셋 및 파일 크기를 검증하여 안정적으로 이어서 업로드할 수 있도록 구성했습니다.

---

## 📝 작업 내용
- 업로드 세션(`UploadSession`) 기반 청크 업로드 흐름 구현
- 청크 업로드 유스케이스(`ChunkUploadUseCase`) 추가
  - 업로드 오프셋 검증
  - 실제 기록된 바이트 수 기준으로 `nextOffset` 갱신
- 파일 기록 로직(`ChunkFileWriter`) 구현
  - 지정 오프셋부터 스트리밍 방식으로 파일 write
- 청크 업로드 API 엔드포인트(`UploadController`) 추가
- 청크 업로드 결과 DTO (`ChunkUploadResult`, `ChunkUploadResponse`) 정의
- 업로드 관련 에러 코드(`FileErrorCode`) 정리

---

## 💭 주의 사항
- 청크 업로드 요청 시 `Upload-Offset` 헤더 값은 **세션의 `nextOffset`과 반드시 일치**해야 합니다.
- 마지막 청크는 고정 크기가 아닌 **남은 바이트 수만큼** 업로드되어야 하며,  
  서버는 실제 기록된 바이트(`written`) 기준으로 오프셋을 갱신합니다.
- 현재는 기능 검증을 위해 수동(curl/dd) 테스트로 확인했으며,  
  자동화 테스트는 추후 단계에서 추가 예정입니다.

---

## 💡 리뷰 포인트
- 청크 업로드 시 오프셋 검증 로직 및 예외 처리 방식이 적절한지
- `ChunkFileWriter`의 스트리밍/오프셋 기반 파일 기록 방식이 안전한지
- `ChunkUploadResult` ↔ `ChunkUploadResponse` 분리 구조가 적절한지
- 업로드 관련 에러 코드(`FileErrorCode`) 분리 수준이 과하지 않은지
- 현재는 단순 유스케이스 형태로 구현되어 있으며, 추후 Command 기반 구조로 전환할 예정입니다.

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
